### PR TITLE
Disable `document` object in parser task context

### DIFF
--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -14,6 +14,7 @@ export default (path, file) => {
     /* When spawning this, we are not a browser anymore. Disable these */
     navigator = undefined;
     window = undefined;
+    document = undefined;
     /* eslint-enable no-native-reassign, no-undef */
 
     require(file);


### PR DESCRIPTION
This should fix #5.

The workaround mentioned in #5 does not work with `gulpfile.babel.js` and messing with globals is not really the best idea anyway. 
Also there could be other modules (mis)using the `document` object in the task context.
