### PR TITLE
Use Gulp's executable rather than parser-task.js

### DIFF
--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -2,8 +2,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import util from 'util';
-import { Task } from 'atom';
 import EventEmitter from 'events';
 import { spawn } from 'child_process';
 
@@ -49,10 +47,12 @@ export function provideBuilder() {
       };
 
       return new Promise((resolve, reject) => {
-        let childEnv = {};
+        const childEnv = {};
 
-        for (let name in process.env) {
-          childEnv[name] = process.env[name];
+        for (const name in process.env) {
+          if (process.env.hasOwnProperty(name)) {
+            childEnv[name] = process.env[name];
+          }
         }
 
         delete childEnv.NODE_ENV;

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -1,12 +1,11 @@
 'use babel';
 
-const originalNodePath = process.env.NODE_PATH;
-
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
 import { Task } from 'atom';
 import EventEmitter from 'events';
+import { spawn } from 'child_process';
 
 export function provideBuilder() {
   return class GulpBuildProvider extends EventEmitter {
@@ -50,12 +49,25 @@ export function provideBuilder() {
       };
 
       return new Promise((resolve, reject) => {
-        /* This is set so that the spawned Task gets its own instance of gulp */
-        process.env.NODE_PATH = util.format('%s%snode_modules%s%s', this.cwd, path.sep, path.delimiter, originalNodePath);
+        let childEnv = {};
 
-        Task.once(require.resolve(__dirname + '/parser-task.js'), this.cwd, this.file, (result) => {
-          process.env.NODE_PATH = originalNodePath;
+        for (let name in process.env) {
+          childEnv[name] = process.env[name];
+        }
 
+        delete childEnv.NODE_ENV;
+        delete childEnv.NODE_PATH;
+
+        const child = spawn('node', [
+          require.resolve(__dirname + '/parser-task.js'),
+          this.file
+        ], {
+          stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ],
+          env: childEnv,
+          cwd: this.cwd
+        });
+
+        child.once('message', (result) => {
           if (result.error) {
             return resolve([ createConfig('Gulp: default', [ 'default' ]) ]);
           }

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import EventEmitter from 'events';
-import { spawn } from 'child_process';
+import { execFile } from 'child_process';
 
 export function provideBuilder() {
   return class GulpBuildProvider extends EventEmitter {
@@ -31,13 +31,16 @@ export function provideBuilder() {
     }
 
     settings() {
-      const createConfig = (name, args) => {
-        const executable = /^win/.test(process.platform) ? 'gulp.cmd' : 'gulp';
+      const gulpCommand = () => {
+        const executable = process.platform === 'win32' ? 'gulp.cmd' : 'gulp';
         const localPath = path.join(this.cwd, 'node_modules', '.bin', executable);
-        const exec = fs.existsSync(localPath) ? localPath : executable;
+        return fs.existsSync(localPath) ? localPath : executable;
+      }();
+
+      const createConfig = (name, args) => {
         return {
           name: name,
-          exec: exec,
+          exec: gulpCommand,
           sh: false,
           args: args,
           env: {
@@ -47,28 +50,19 @@ export function provideBuilder() {
       };
 
       return new Promise((resolve, reject) => {
-        const childEnv = {};
-
-        for (const name in process.env) {
-          if (process.env.hasOwnProperty(name)) {
-            childEnv[name] = process.env[name];
-          }
-        }
+        const childEnv = Object.assign({}, process.env);
 
         delete childEnv.NODE_ENV;
         delete childEnv.NODE_PATH;
 
-        const child = spawn('node', [
-          require.resolve(__dirname + '/parser-task.js'),
-          this.file
+        execFile(gulpCommand, [
+          '--tasks-simple',
+          '--gulpfile=' + this.file
         ], {
-          stdio: [ 'ignore', 'ignore', 'ignore', 'ipc' ],
           env: childEnv,
           cwd: this.cwd
-        });
-
-        child.once('message', (result) => {
-          if (result.error) {
+        }, (error, stdout, stderr) => {
+          if (error !== null) {
             return resolve([ createConfig('Gulp: default', [ 'default' ]) ]);
           }
 
@@ -79,8 +73,16 @@ export function provideBuilder() {
           }));
 
           const config = [];
+          let tasks = stdout.toString().trim();
+
+          if (tasks === '') {
+            tasks = [];
+          } else {
+            tasks = tasks.split('\n');
+          }
+
           /* Make sure 'default' is the first as this will be the prioritized target */
-          result.tasks.sort((t1, t2) => {
+          tasks.sort((t1, t2) => {
             if ('default' === t1) {
               return -1;
             }
@@ -89,7 +91,7 @@ export function provideBuilder() {
             }
             return t1.localeCompare(t2);
           });
-          (result.tasks || []).forEach((task) => {
+          tasks.forEach((task) => {
             config.push(createConfig('Gulp: ' + task, [ task ]));
           });
 

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -1,9 +1,0 @@
-try {
-  const gulpfile = process.argv[2];
-  const gulp = require(process.cwd() + '/node_modules/gulp');
-
-  require(gulpfile);
-  process.send({ tasks: Object.keys(gulp.tasks) });
-} catch (e) {
-  process.send({ error: { message: e.message || e.code } });
-}

--- a/lib/parser-task.js
+++ b/lib/parser-task.js
@@ -1,25 +1,9 @@
-'use babel';
+try {
+  const gulpfile = process.argv[2];
+  const gulp = require(process.cwd() + '/node_modules/gulp');
 
-/**
- * This has to be done in a separate task since gulp depends
- * on stuff that does unsafe evals. We don't want, and are not
- * allowed to do this in the context of the Atom application.
- */
-
-export default (path, file) => {
-  try {
-    const gulp = require(`${path}/node_modules/gulp`);
-
-    /* eslint-disable no-native-reassign, no-undef */
-    /* When spawning this, we are not a browser anymore. Disable these */
-    navigator = undefined;
-    window = undefined;
-    document = undefined;
-    /* eslint-enable no-native-reassign, no-undef */
-
-    require(file);
-    return { tasks: Object.keys(gulp.tasks) };
-  } catch (e) {
-    return { error: { message: e.message || e.code } };
-  }
-};
+  require(gulpfile);
+  process.send({ tasks: Object.keys(gulp.tasks) });
+} catch (e) {
+  process.send({ error: { message: e.message || e.code } });
+}


### PR DESCRIPTION
Fixes #8.
- Use a node process rather than Atom to allow for native modules to be used in gulpfiles
- Use Gulp's executable rather than `parser-task.js` to provide support for gulpfiles which depend on Babel or CoffeeScript
