### PR TITLE
Use exec instead of execFile, surround paths with quotes

### DIFF
--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import EventEmitter from 'events';
-import { execFile } from 'child_process';
+import { exec } from 'child_process';
 
 export function provideBuilder() {
   return class GulpBuildProvider extends EventEmitter {
@@ -55,10 +55,7 @@ export function provideBuilder() {
         delete childEnv.NODE_ENV;
         delete childEnv.NODE_PATH;
 
-        execFile(gulpCommand, [
-          '--tasks-simple',
-          '--gulpfile=' + this.file
-        ], {
+        exec(`"${gulpCommand}" --tasks-simple --gulpfile="${this.file}"`, {
           env: childEnv,
           cwd: this.cwd
         }, (error, stdout, stderr) => {


### PR DESCRIPTION
This fixes #12. I tested this on Atom 1.8.0-beta3 on Windows 7.

The [`exec`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) function will launch Command Prompt and handle its quotation mark issues for us.

The [`atom-build`](https://github.com/noseglid/atom-build) package's build procedure is unaffected because it uses [`cross-spawn-async`](https://www.npmjs.com/package/cross-spawn-async), which could be an option here, if this does not work correctly on other Atom versions.
