### PR TITLE
Display error notification when loading/refreshing build targets fails

### DIFF
--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -60,6 +60,11 @@ export function provideBuilder() {
           cwd: this.cwd
         }, (error, stdout, stderr) => {
           if (error !== null) {
+            atom.notifications.addError('Failed to parse gulpfile to parse gulpfile for targets', {
+              detail: (stdout ? 'Output:\n' + stdout + '\n' : '') + 'Error:\n' + stderr,
+              dismissable: true,
+              icon: 'bug'
+            });
             return resolve([ createConfig('Gulp: default', [ 'default' ]) ]);
           }
 


### PR DESCRIPTION
fixes AtomBuild/atom-build-gulp#15
